### PR TITLE
Convert site header to text

### DIFF
--- a/streetlight-app/src/app/app.component.html
+++ b/streetlight-app/src/app/app.component.html
@@ -1,6 +1,7 @@
 <div id="main">
   <header fxLayout="row" fxLayoutAlign="center center" >
-    <img id="site-logo" src="../assets/streetlight-app-logo.png" alt="">
+<!--<img id="site-logo" src="../assets/streetlight-app-logo.png" alt=""> -->
+    <a href="" (click)="onModeShiftClick('landing')"><h1 id="site-header">Streetlights</h1></a>
   </header>
   <content>
     <div id="mode-shifter" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="16px">

--- a/streetlight-app/src/app/app.component.scss
+++ b/streetlight-app/src/app/app.component.scss
@@ -1,9 +1,17 @@
+// Font for the site header
+@import url('https://fonts.googleapis.com/css?family=Poiret+One&display=swap');
 
 header {
     /* background-color: #0f0314; */
     border-bottom: 1px solid var(--color-primary-4);
 }
-  
+
+#site-header {
+  // The "Streetlights" header at the top of the page
+  font-family: 'Poiret One', cursive;
+  font-size: 400%;
+  color: var(--color-primary-0);
+}
 
  #mode-shifter {
      /* text-align: center; */
@@ -17,4 +25,3 @@ header {
  #mode-shifter i:hover {
     color: var(--color-primary-4);
  }
-


### PR DESCRIPTION
The site header is now a standard <h1> with the same font, size, and color as the logo image.